### PR TITLE
TASK-3: Add User and Role entities with JPA relationships

### DIFF
--- a/restaurant-management/pom.xml
+++ b/restaurant-management/pom.xml
@@ -34,7 +34,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
+			<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/model/Role.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/model/Role.java
@@ -1,0 +1,26 @@
+package com.restaurant.restaurant_management.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Entity representing a role assigned to users.
+ */
+@Entity
+@Table(name = "roles")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, unique = true)
+    private RoleType roleType;
+
+
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/model/RoleType.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/model/RoleType.java
@@ -1,0 +1,12 @@
+package com.restaurant.restaurant_management.model;
+
+
+
+/**
+ * Enum for defining user roles.
+ */
+public enum RoleType {
+    ADMIN,
+    STAFF,
+    CUSTOMER
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/model/User.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/model/User.java
@@ -1,0 +1,44 @@
+package com.restaurant.restaurant_management.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Entity representing application users.
+ */
+@Entity
+@Table(name = "users", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"username"}),
+        @UniqueConstraint(columnNames = {"email"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String username;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ManyToMany(fetch = FetchType.EAGER) // Load roles with user
+    @JoinTable(
+            name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/CategoryRepository.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.restaurant.restaurant_management.repository;
+
+import com.restaurant.restaurant_management.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/MenuItemRepository.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/MenuItemRepository.java
@@ -1,0 +1,10 @@
+package com.restaurant.restaurant_management.repository;
+
+
+import com.restaurant.restaurant_management.model.MenuItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/OrderItemRepository.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/OrderItemRepository.java
@@ -1,0 +1,9 @@
+package com.restaurant.restaurant_management.repository;
+
+import com.restaurant.restaurant_management.model.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/OrderRepository.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package com.restaurant.restaurant_management.repository;
+
+import com.restaurant.restaurant_management.model.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/RestaurantRepository.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/RestaurantRepository.java
@@ -1,0 +1,9 @@
+package com.restaurant.restaurant_management.repository;
+
+import com.restaurant.restaurant_management.model.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RestaurantRepository  extends JpaRepository<Restaurant, Long> {
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/RoleRepository.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/RoleRepository.java
@@ -1,0 +1,7 @@
+package com.restaurant.restaurant_management.repository;
+
+import com.restaurant.restaurant_management.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+}

--- a/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/UserRepository.java
+++ b/restaurant-management/src/main/java/com/restaurant/restaurant_management/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.restaurant.restaurant_management.repository;
+import com.restaurant.restaurant_management.model.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
- Added `RoleName` enum for predefined roles (ADMIN, STAFF, CUSTOMER)
- Created `Role` entity with role name
- Created `User` entity with username, email, password, and many-to-many roles relationship
- Configured bidirectional JPA mappings and constraints
- Applied Lombok for cleaner code
